### PR TITLE
A more principled approach on authentication

### DIFF
--- a/draft-thomson-http-encryption.md
+++ b/draft-thomson-http-encryption.md
@@ -403,9 +403,9 @@ following information MUST be established out of band:
   sequence of octets and MUST NOT include a zero-valued octet.
 
 * The format of the ephemeral public share that is included in the "dh"
-  parameter.  This encoding MUST result in a single sequence of octets.  For
-  instance, using ECDH both parties need to agree whether this is an
-  uncompressed or compressed point.
+  parameter.  This encoding MUST result in a single, canonical sequence of
+  octets.  For instance, using ECDH both parties need to agree whether this is
+  an uncompressed or compressed point.
 
 In addition to identifying which content-encoding this input keying material is
 used for, the "keyid" parameter is used to identify this additional information
@@ -417,8 +417,10 @@ a shared secret using the designated Diffie-Hellman process.
 The context for content encryption key and nonce derivation (see {{derivation}})
 is set to include the means by which the keys were derived.  The context is
 formed from the concatenation of group label, a single zero octet, the length of
-the public key of the recipient, the encoded public key of the recipient, the
-length of the public key of the sender, and the public key of the sender:
+the public key of the recipient, the public key of the recipient, the length of
+the public key of the sender, and the public key of the sender.  The public keys
+are encoded into octets as defined for the group when determining the context
+string.
 
 ~~~
    context = label || 0x00 ||

--- a/draft-thomson-http-encryption.md
+++ b/draft-thomson-http-encryption.md
@@ -453,17 +453,18 @@ input keying material used to derive the content encryption key and nonce
 
 The authentication secret is used as the "salt" parameter to HKDF, the raw
 keying material (e.g., Diffie-Hellman output) is used as the "IKM" parameter,
-the ASCII-encoded string "Content-Encoding: auth" with a terimal zero octet is
+the ASCII-encoded string "Content-Encoding: auth" with a terminal zero octet is
 used as the "info" parameter, and the length of the output is 32 octets (i.e.,
 the entire output of the underlying SHA-256 HMAC function):
 
 ~~~
-   auth_context = "Content-Encoding: auth" || 0x00
-   IKM = HKDF(authentication, raw_key, auth_context, 32)
+   auth_info = "Content-Encoding: auth" || 0x00
+   IKM = HKDF(authentication, raw_key, auth_info, 32)
 ~~~
 
-This invocation of HKDF does not take the same additional context that is
-provided to the final key derivation stages.
+This invocation of HKDF does not take the same context that is provided to the
+final key derivation stages.  Alternatively, this phase can be viewed as always
+having a zero-length context.
 
 Note that in the absence of an authentication secret, the input keying material
 is simply the raw keying material:

--- a/draft-thomson-http-encryption.md
+++ b/draft-thomson-http-encryption.md
@@ -211,7 +211,7 @@ The `Encryption` header field uses the extended ABNF syntax defined in
 Section 1.2 of [RFC7230] and the `parameter` rule from [RFC7231]
 
 ~~~
-  Encryption-val = #encryption_params
+  Encryption = #encryption_params
   encryption_params = [ parameter *( ";" parameter ) ]
 ~~~
 
@@ -337,7 +337,7 @@ The Crypto-Key header field uses the extended ABNF syntax defined in Section 1.2
 of [RFC7230] and the `parameter` rule from [RFC7231].
 
 ~~~
-  Crypto-Key-val = #crypto_key_params
+  Crypto-Key = #crypto_key_params
   crypto_key_params = [ parameter *( ";" parameter ) ]
 ~~~
 

--- a/draft-thomson-http-encryption.md
+++ b/draft-thomson-http-encryption.md
@@ -509,17 +509,18 @@ reasons only.
 HTTP/1.1 200 OK
 Content-Length: 32
 Content-Encoding: aesgcm128
-Encryption: keyid="dhkey"; salt="BXlfKQLkr1Uye5npraPXsw"
+Encryption: keyid="dhkey"; salt="Qg61ZJRva_XBE9IEUelU3A"
 Crypto-Key: keyid="dhkey";
-                dh="BAAchS17kTRTkYanibzO_L4jrHf91xu5ntQg5mHllLdS
-		    NYoiuOBoQwMSx0eUWjrt3p0fSnoEMlwAe-Kbom_b0q0"
+                dh="BDgpRKok2GZZDmS4r63vbJSUtcQx4Fq1V58-6-3NbZzS
+                    TlZsQiCEDTQy3CZ0ZMsqeqsEb7qW2blQHA4S48fynTk"
 
-UNkrli1bKtIa_k8gq_z4ASltJFQOarvE76gQ__iImLc
+G6j_sfKg0qebO62yXpTCayN2KV24QitNiTvLgcFiEj0
 ~~~
 
 This example shows the same string, "I am the walrus", encrypted using ECDH over
-the P-256 curve [FIPS186]. The content body is shown here encoded in URL-safe
-base64 for presentation reasons only.
+the P-256 curve [FIPS186], which is identified with the label "P-256" encoded in
+ASCII. The content body is shown here encoded in URL-safe base64 for
+presentation reasons only.
 
 The receiver (in this case, the HTTP client) uses a key pair that is identified
 by the string "dhkey" and the sender (the server) uses a key pair for which the
@@ -529,11 +530,11 @@ added for presentation purposes only.
 
 ~~~
    Receiver:
-      private key: c2FFWBracEQR_EiVp8l9zBG-bbZI2qzTbz4dlEvzpCE
-      public key: BDzMceVKKGnijK94B-j0BnmhvKEwiAyhvmpgo7D-yvMB
-                  RBfuPnLfaaDau47K_isqoQRJJGR33GcENUUjohECyNs
+      private key: 9FWl15_QUQAWDaD3k3l50ZBZQJ4au27F1V4F0uLSD_M
+      public key: BCEkBjzL8Z3C-oi2Q7oE5t2Np-p7osjGLg93qUP0wvqR
+                  T21EEWyf0cQDQcakQMqz4hQKYOQ3il2nNZct4HgAUQU
    Sender:
-      private key: f0vn_1qHZmluyKDzQncncko0Y3UMkqiiRYbV3PuB2P4
+      private key: vG7TmzUX9NfVR4XUGBkLAFu8iDyQe-q_165JkkN0Vlw
       public key: <the value of the "dh" parameter>
 ~~~
 

--- a/draft-thomson-http-encryption.md
+++ b/draft-thomson-http-encryption.md
@@ -284,6 +284,10 @@ aesgcm128", a single zero octet and an optional context string:
    cek_info = "Content-Encoding: aesgcm128" || 0x00 || context
 ~~~
 
+Unless otherwise specified, the context is a zero length octet sequence.
+Specifications that use this content encoding MAY specify the use of an expanded
+context to cover additional inputs in the key derivation.
+
 AEAD_AES_128_GCM requires a 16 octet (128 bit) content encryption key, so the
 length (L) parameter to HKDF is 16.  The second step of HKDF can
 therefore be simplified to the first 16 octets of a single HMAC:
@@ -310,7 +314,8 @@ context:
    nonce_info = "Content-Encoding: nonce" || 0x00 || context
 ~~~
 
-Unless otherwise specified, the context is a zero length octet sequence.
+The context for nonce derivation SHOULD be the same as is used for content
+encryption key derivation.
 
 The result is combined with the record sequence number - using exclusive or - to
 produce the nonce.  The record sequence number (SEQ) is a 96-bit unsigned

--- a/draft-thomson-http-encryption.md
+++ b/draft-thomson-http-encryption.md
@@ -454,11 +454,12 @@ input keying material used to derive the content encryption key and nonce
 The authentication secret is used as the "salt" parameter to HKDF, the raw
 keying material (e.g., Diffie-Hellman output) is used as the "IKM" parameter,
 the ASCII-encoded string "Content-Encoding: auth" with a terimal zero octet is
-used as the "info" parameter, and the length of the output is 16 octets:
+used as the "info" parameter, and the length of the output is 32 octets (i.e.,
+the entire output of the underlying SHA-256 HMAC function):
 
 ~~~
    auth_context = "Content-Encoding: auth" || 0x00
-   IKM = HKDF(authentication, raw_key, auth_context, 16)
+   IKM = HKDF(authentication, raw_key, auth_context, 32)
 ~~~
 
 This invocation of HKDF does not take the same additional context that is


### PR DESCRIPTION
Based on the feedback from @agl, I've moved to a more principled position on mixing authentication secrets into the keying material.  I've done some more reading on HKDF and this seems to be a cleaner design.  It also looks a lot more like the TLS 1.3 key derivation when a separate authentication secret is used.

I won't pretend that this is anywhere as solid a design as TLS.  Critically, I don't have time right now to work up a formal model, and there are a few things I need to chase down.

This supercedes #4 but it only builds on it.
